### PR TITLE
Updated the projects and the corresponding references to .NET core 2.0

### DIFF
--- a/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams.Demo/EntityFrameworkCore.Diagrams.Demo.csproj
+++ b/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams.Demo/EntityFrameworkCore.Diagrams.Demo.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="1.1.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="2.0.0-preview1" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.1" />

--- a/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams/Dto/DbEntityForeignKeyBase.cs
+++ b/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams/Dto/DbEntityForeignKeyBase.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Metadata;
+﻿using Microsoft.EntityFrameworkCore;
 
 namespace EntityFrameworkCore.Diagrams.Dto
 {

--- a/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams/Dto/DtoConverter.cs
+++ b/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams/Dto/DtoConverter.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using EntityFrameworkCore.Diagrams.Dto;
 using System.Linq;
 using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace EntityFrameworkCore.Diagrams.Dto
 {
@@ -64,11 +65,11 @@ namespace EntityFrameworkCore.Diagrams.Dto
                 ClrType = ConvertToDto(e.ClrType),
                 IsConcurrencyToken = e.IsConcurrencyToken,
                 IsNullable = e.IsNullable,
-                IsReadOnlyAfterSave = e.IsReadOnlyAfterSave,
-                IsReadOnlyBeforeSave = e.IsReadOnlyBeforeSave,
+                IsReadOnlyAfterSave = e.AfterSaveBehavior == PropertySaveBehavior.Throw,
+                IsReadOnlyBeforeSave = e.BeforeSaveBehavior == PropertySaveBehavior.Throw,
                 IsShadowProperty = e.IsShadowProperty,
-                IsStoreGeneratedAlways = e.IsStoreGeneratedAlways,
-                RequiresValueGenerator = e.RequiresValueGenerator,
+                IsStoreGeneratedAlways = e.BeforeSaveBehavior == PropertySaveBehavior.Ignore,
+                RequiresValueGenerator = e.RequiresValueGenerator(),
                 ValueGenerated = e.ValueGenerated
             };
         }

--- a/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams.csproj
+++ b/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams.csproj
@@ -30,7 +30,7 @@ https://github.com/EvAlex/ef-db-diagrams
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <AssemblyVersion>0.4.2.0</AssemblyVersion>
     <FileVersion>0.4.2.0</FileVersion>
@@ -41,11 +41,11 @@ https://github.com/EvAlex/ef-db-diagrams
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EntityFrameworkCore.Diargams
+# EntityFrameworkCore.Diagrams
 
 Visualize model created with EntityFramework Core in ASP.NET Core app.
 


### PR DESCRIPTION
Hi,

I really like your project and appreciate the work you already put into this. Unfortunately I could not use it in my current project due to the fact that this lib is not yet based on .NET core 2.0 and unfortunately it is also not compatible. This is because the guys from Microsoft i.e. moved the DeleteBehavior to another namespace.
I updated the project, maybe this was also on your agenda. If you plan to update, please feel free to get the changes from my fork.