### PR TITLE
Those 2 extra params create a directory that doesn't exist

### DIFF
--- a/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams/EfDiagramsOptions.cs
+++ b/EntityFrameworkCore.Diagrams/EntityFrameworkCore.Diagrams/EfDiagramsOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (!Directory.Exists(contentRoot))
             {
                 //  NOTE: this means that we are not installed as NuGet packange
-                contentRoot = Path.Combine(dllPath, "..", "..", "..", "..", "EntityFrameworkCore.Diagrams");
+                contentRoot = Path.Combine(dllPath, "..", "..", "..");
             }
             contentRoot = Path.Combine(contentRoot, "wwwroot", "db-diagrams");
             return contentRoot;


### PR DESCRIPTION
NET Core 5


System.IO.DirectoryNotFoundException

https://github.com/EvAlex/ef-db-diagrams/issues/49
https://github.com/EvAlex/ef-db-diagrams/issues/48